### PR TITLE
Added language selector in settings for Galician, Basque

### DIFF
--- a/res/layout/preferences.xml
+++ b/res/layout/preferences.xml
@@ -7,7 +7,7 @@
     <LinearLayout
         android:id="@+id/linearLayout1"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:orientation="vertical"
         android:padding="5dp" >
 
@@ -126,9 +126,8 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical" 
-            android:layout_marginBottom="10dp"
-            android:layout_marginTop="10dp">
+            android:layout_marginTop="20dp"
+            android:orientation="vertical" >
 
             <TextView
                 android:id="@+id/tvLanguageSettings"
@@ -170,7 +169,7 @@
         <RelativeLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="50dp" >
+            android:layout_marginTop="20dp" >
 
             <TextView
                 android:id="@+id/tutorial_link"
@@ -180,6 +179,7 @@
                 android:layout_centerInParent="true"
                 android:text="@string/tutorial_link" />
         </RelativeLayout>
+
     </LinearLayout>
 
 </ScrollView>

--- a/res/values-ca/strings.xml
+++ b/res/values-ca/strings.xml
@@ -160,10 +160,11 @@
     <string name="import_metadata">Importar metadades?</string>
     <string name="import_metadata_desc">Vols establir la data, l\'hora, i la localització de la imatge a partir de les seves metadades?</string>
     <string name="language_settings">Opcions d\'idioma</string>
-    <string name="locale_gl">Galego</string>
+    <string name="locale_gl">Gallego</string>
     <string name="locale_eu">Euskera</string>
     <string name="use_device_language_settings">Usar opcions d\'idioma del terminal.</string>
     <string name="language_restart">Opcions d\'idioma canviades. Si us plau reinicia l\'aplicació per veure els canvis.</string>
+    <string name="restart_now">Reinicia ara</string>
     <string-array name="tutorial_images">
     <item>tutorial1</item>
     <item>tutorial2</item>

--- a/res/values-en/strings.xml
+++ b/res/values-en/strings.xml
@@ -158,10 +158,11 @@
     <string name="import_metadata">Import metadata?</string>
     <string name="import_metadata_desc">Do you want to set the date, time, and location of this observation from the photo\'s metadata?</string>
     <string name="language_settings">Language settings</string>
-    <string name="locale_gl">Galego</string>
-    <string name="locale_eu">Euskera</string>
+    <string name="locale_gl">Galician</string>
+    <string name="locale_eu">Basque</string>
     <string name="use_device_language_settings">Use device language settings</string>
     <string name="language_restart">Language settings changed. Please restart the app for the changes to take place.</string>
+    <string name="restart_now">Restart now</string>
 
     <string-array name="tutorial_images">
 	    <item>tutorial1</item>

--- a/res/values-es-rES/strings.xml
+++ b/res/values-es-rES/strings.xml
@@ -160,10 +160,11 @@
     <string name="import_metadata">Importar metadatos?</string>
     <string name="import_metadata_desc">¿Quieres establecer la fecha, la hora, y la localización de la imágen a partir de sus metadatos?</string>
     <string name="language_settings">Opciones de idioma</string>
-    <string name="locale_gl">Galego</string>
+    <string name="locale_gl">Gallego</string>
     <string name="locale_eu">Euskera</string>
     <string name="use_device_language_settings">Usar las opciones de idioma del terminal</string>
     <string name="language_restart">Opciones de idioma cambiadas. Por favor reinicie el terminal para ver los cambios.</string>
+    <string name="restart_now">Reiniciar ahora</string>
     <string-array name="tutorial_images">
     <item>tutorial1</item>
     <item>tutorial2</item>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -158,10 +158,11 @@
     <string name="import_metadata">Importar metadatos?</string>
     <string name="import_metadata_desc">¿Quieres configurar la fecha, hora y lugar de esta observación de los metadatos de la foto?</string>
     <string name="language_settings">Opciones de idioma</string>
-    <string name="locale_gl">Galego</string>
+    <string name="locale_gl">Gallego</string>
     <string name="locale_eu">Euskera</string>
     <string name="use_device_language_settings">Usar las opciones de idioma del terminal</string>
     <string name="language_restart">Opciones de idioma cambiadas. Por favor reinicie el terminal para ver los cambios.</string>
+    <string name="restart_now">Restart now</string>
  
     <string-array name="tutorial_images">
 	    <item>tutorial1</item>

--- a/res/values-eu/strings.xml
+++ b/res/values-eu/strings.xml
@@ -160,10 +160,11 @@
     <string name="import_metadata">Metadatuak inportatu?</string>
     <string name="import_metadata_desc">Irudiaren data, ordua eta kokalekua bere metadatuetatik jarri nahi dituzu?</string>
     <string name="language_settings">Hizkuntza aukerak</string>
-    <string name="locale_gl">Galego</string>
+    <string name="locale_gl">Galiziar</string>
     <string name="locale_eu">Euskera</string>
     <string name="use_device_language_settings">Terminaleko hizkuntza aukerak erabili itzazu</string>
     <string name="language_restart">Hizkuntza aukerak aldatu dituzu. Aplikazioa berrabiarazi mesedez.</string>
+    <string name="restart_now">Berrabiarazi orain</string>
     <string-array name="tutorial_images">
     <item>tutorial1</item>
     <item>tutorial2</item>

--- a/res/values-gl/strings.xml
+++ b/res/values-gl/strings.xml
@@ -164,6 +164,7 @@
     <string name="locale_eu">Euskera</string>
     <string name="use_device_language_settings">Usar as opcións de idioma do terminal</string>
     <string name="language_restart">Opcións de idioma cambiadas. Por favor, reinicia a aplicación.</string>
+    <string name="restart_now">Reiniciar agora</string>
     <string-array name="tutorial_images">
     <item>tutorial1</item>
     <item>tutorial2</item>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -187,10 +187,11 @@
 	<string name="gmaps2_api_key"></string>
 	<string name="oauth_client_id"></string>
 	<string name="language_settings">Language settings</string>
-	<string name="locale_gl">Galego</string>
-	<string name="locale_eu">Euskera</string>
+	<string name="locale_gl">Galician</string>
+	<string name="locale_eu">Basque</string>
 	<string name="use_device_language_settings">Use device language settings</string>
 	<string name="language_restart">Language settings changed. Please restart the app for the changes to take place.</string>
+	<string name="restart_now">Restart now</string>
     
     <string-array name="tutorial_images">
 	    <item>tutorial1</item>

--- a/src/org/inaturalist/android/INaturalistApp.java
+++ b/src/org/inaturalist/android/INaturalistApp.java
@@ -35,25 +35,46 @@ public class INaturalistApp extends Application {
     private static Integer SYNC_NOTIFICATION = 3;
     private static Context context;
     private Locale locale = null;
+    private Locale deviceLocale = null;
     
     @Override
     public void onCreate() {
         super.onCreate();
         mNotificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
         INaturalistApp.context = getApplicationContext();
-        
-        SharedPreferences settings = getPrefs();
+        deviceLocale = getResources().getConfiguration().locale;
+        applyLocaleSettings();
+    }
+    
+    public String getFormattedDeviceLocale(){
+    	if(deviceLocale!=null){
+    		return deviceLocale.getDisplayLanguage();
+    	}    	
+    	return "";
+    }
+    
+    public void applyLocaleSettings(){
+    	SharedPreferences settings = getPrefs();
 
         Configuration config = getBaseContext().getResources().getConfiguration();
-
+        
         String lang = settings.getString("pref_locale", "");
         if (! "".equals(lang) && ! config.locale.getLanguage().equals(lang))
         {
-            locale = new Locale(lang);
-            Locale.setDefault(locale);
-            config.locale = locale;
-            getBaseContext().getResources().updateConfiguration(config, getBaseContext().getResources().getDisplayMetrics());
+            locale = new Locale(lang);            
+        }else{        	
+        	locale = deviceLocale;
         }
+        Locale.setDefault(locale);
+        config.locale = locale;
+        getBaseContext().getResources().updateConfiguration(config, getBaseContext().getResources().getDisplayMetrics());
+    }
+    
+    public void restart(){
+    	Intent i = getBaseContext().getPackageManager()
+	             .getLaunchIntentForPackage( getBaseContext().getPackageName() );
+	    i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+	    startActivity(i);
     }
     
     @Override


### PR DESCRIPTION
Added a custom language selector in settings to make Galician and Basque translations visible. The selector control is in the Settings menu, right above the manual link. 

The modifications that allow setting of a custom locale are based on this post:

http://stackoverflow.com/questions/2264874/changing-locale-within-the-app-itself

The control itself is a radio button with 3 options:
- Default terminal setting -> Takes locale from device
- Galician -> Forces loading the locale "gl"
- Basque -> Forces loading the locale "eu"

When the users selects an option, the preferred locale is saved to preferences with the key "pref_locale". Changing this option requires restart of the app to see the changes. If the user does so, the next time the app starts it loads all the app strings in the last selected language.
