### PR TITLE
Make observation tabs consistent with explore tabs

### DIFF
--- a/iNaturalist/src/main/res/layout/observation_list.xml
+++ b/iNaturalist/src/main/res/layout/observation_list.xml
@@ -7,7 +7,7 @@
     <com.google.android.material.tabs.TabLayout
         android:id="@+id/tabs"
         android:layout_width="match_parent"
-        android:layout_height="60dp"
+        android:layout_height="65dp"
         app:tabMode="fixed"
         app:tabGravity="fill"
         app:tabIndicatorColor="@color/inatapptheme_color"


### PR DESCRIPTION
This makes a slightly more consistent UX as users browse from one app screen to the next (specifically, from explore to 'my observations'). I noticed this specific issue because I use a large font on my device, and the explore tabs work fine while My Observations tabs had text cut off. An easy fix is to make their height consistent. Photo shows trimmed text - this same font size displays tabs correctly on the 'Explore' page

![Screenshot_20200426-110532](https://user-images.githubusercontent.com/305380/80311561-564a7180-87ae-11ea-8180-d4f880959759.png)

Please note there are multiple other differences between these two screens. I'm not versed in this project, but some more tweaks might be desired for more consistency! For example, their selection indicator is different (Explore makes the tab text **BOLD** which works nice, while My Observations changes text color from gray to black without bold which is hard to see). Also, selected tab in My Observations has an odd tab divider line. You can see this in the screenshot, the vertical divider line for the selected tab is split in two - one main line, a small bit of spacing, and then a small vertical mark that looks like a mistake. 

```
 [master] layout$ diff explore.xml observation_list.xml
2c2
< <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
---
> <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
4,5c4,5
<     android:orientation="vertical" android:layout_width="match_parent"
<     android:layout_height="match_parent">
---
>     android:layout_width="fill_parent"
>     android:layout_height="fill_parent">
10,12c10,11
<         android:layout_height="65dp"
<         android:layout_gravity="bottom"
<         app:tabMode="scrollable"
---
>         android:layout_height="60dp"
>         app:tabMode="fixed"
15d13
<         app:tabPadding="0dp"
18a17
>         android:layout_alignParentTop="true"
21a21
>
23d22
<         app:layout_behavior="@string/appbar_scrolling_view_behavior"
24a24
>         android:layout_below="@id/tabs"
26,27c26,28
<         android:layout_height="match_parent"
<         android:background="#F5F5F5" />
---
>         android:layout_height="match_parent" />
>
> </RelativeLayout>
30d30
< </LinearLayout>
```
