### PR TITLE
Fix example config values

### DIFF
--- a/iNaturalist/src/main/res/values/config.example.xml
+++ b/iNaturalist/src/main/res/values/config.example.xml
@@ -2,7 +2,7 @@
 <!-- copy this file to config.xml and uncomment / fill in the values specific to your project -->
 <resources>
     <!-- https://developers.google.com/maps/documentation/android/ -->
-    <!-- <string name="gmaps_api_key">xxx</string>  -->
+    <!-- <string name="gmaps2_api_key">xxx</string>  -->
 
     <!-- Used by the app to do anonymous JWT authentication (when user is not logged in) -->
     <!-- <string name="jwt_anonymous_api_secret"></string> -->

--- a/iNaturalist/src/main/res/values/config.example.xml
+++ b/iNaturalist/src/main/res/values/config.example.xml
@@ -12,9 +12,15 @@
 
     <!-- http://www.inaturalist.org/oauth/applications -->
     <!-- <string name="oauth_client_id">xxx</string>  -->
+    
+    <!-- http://www.inaturalist.org/oauth/applications -->
+    <!-- <string name="oauth_client_secret">xxx</string>-->
 
     <!-- Support email address -->
     <!-- <string name="inat_support_email_address">help@yoursite.org</string> -->
+    
+    <!-- Support email URL -->
+    <!-- <string name="inat_help_url">www.help_me.please</string>-->
 
     <!-- URL explaining about the iNaturalist networks  -->
     <!-- <string name="inat_network_info_url">http://www.inaturalist.org/pages/network</string> -->


### PR DESCRIPTION
As shown below, the proper key has changed names from gmaps to gmaps2:

iNaturalist/src/main/java/org/inaturalist/android/INaturalistService.java:                    .apiKey(getString(R.string.gmaps2_api_key))
iNaturalist/src/main/java/org/inaturalist/android/INaturalistApp.java:            Places.initialize(this, getString(R.string.gmaps2_api_key));