### PR TITLE
Observation list performance improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url "http://dl.bintray.com/populov/maven" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:4.1.1'
         classpath 'com.google.gms:google-services:4.3.3'
         classpath 'com.google.firebase:firebase-crashlytics-gradle:2.3.0'
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Sep 16 12:07:07 PDT 2020
+#Thu Dec 31 15:04:40 EST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip

--- a/iNaturalist/src/main/java/org/inaturalist/android/CommentsIdsAdapter.java
+++ b/iNaturalist/src/main/java/org/inaturalist/android/CommentsIdsAdapter.java
@@ -1,7 +1,6 @@
 package org.inaturalist.android;
 
 import java.sql.Timestamp;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
@@ -10,6 +9,7 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.time.FastDateFormat;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.json.JSONArray;
@@ -542,13 +542,13 @@ public class CommentsIdsAdapter extends ArrayAdapter<BetterJSONObject> implement
     public static String formatIdDate(Context context, Timestamp postDate) {
         Duration difference = new Duration(postDate.getTime(), (new Date()).getTime());
         long days = difference.getStandardDays();
-        long hours = difference.getStandardHours();
-        long minutes = difference.getStandardMinutes();
 
         if (days <= 30) {
             // Less than 30 days ago - display as 3m (mins), 3h (hours), 3d (days) or 3w (weeks)
             if (days < 1) {
+				long hours = difference.getStandardHours();
                 if (hours < 1) {
+					long minutes = difference.getStandardMinutes();
                     return String.format(context.getString(R.string.date_minute), minutes);
                 } else {
                     return String.format(context.getString(R.string.date_hour), hours);
@@ -565,7 +565,7 @@ public class CommentsIdsAdapter extends ArrayAdapter<BetterJSONObject> implement
             calDate.setTimeInMillis(postDate.getTime());
 
             String dateFormatString;
-            if (today.get(Calendar.YEAR) > calDate.get(Calendar.YEAR)) {
+            if (today.get(Calendar.YEAR) != calDate.get(Calendar.YEAR)) {
                 // Previous year(s)
                 dateFormatString = context.getString(R.string.date_short);
             } else {
@@ -573,7 +573,7 @@ public class CommentsIdsAdapter extends ArrayAdapter<BetterJSONObject> implement
                 dateFormatString = context.getString(R.string.date_short_this_year);
             }
 
-            SimpleDateFormat dateFormat = new SimpleDateFormat(dateFormatString);
+			FastDateFormat dateFormat = FastDateFormat.getInstance(dateFormatString);
             return dateFormat.format(new Date(postDate.getTime()));
         }
     }

--- a/iNaturalist/src/main/java/org/inaturalist/android/INaturalistApp.java
+++ b/iNaturalist/src/main/java/org/inaturalist/android/INaturalistApp.java
@@ -69,6 +69,7 @@ import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Debug;
 import android.os.Handler;
 import android.os.LocaleList;
 import androidx.annotation.NonNull;
@@ -79,6 +80,8 @@ import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import androidx.core.content.PermissionChecker;
 import androidx.core.content.res.ResourcesCompat;
+
+import android.os.Trace;
 import android.telephony.TelephonyManager;
 import android.text.format.DateFormat;
 import android.util.DisplayMetrics;
@@ -1253,27 +1256,45 @@ public class INaturalistApp extends MultiDexApplication {
     }
 
 
+    /**
+     * Checks if either JVM or Native memory is running low
+     *
+     * TODO {@link ActivityManager#getMemoryInfo(ActivityManager.MemoryInfo)} specifically says not
+     * to poll, which we are doing. This is pretty slow as it does IPC.
+     */
     public boolean isLowMemory() {
+        Trace.beginSection("isLowMem");
+
+        // Check JVM memory
         Runtime runtime = Runtime.getRuntime();
         long usedMem = (runtime.totalMemory() - runtime.freeMemory());
         long maxHeapSize = runtime.maxMemory();
         long availableHeapSize = maxHeapSize - usedMem;
         float freeHeapPercentage = (float)availableHeapSize / maxHeapSize;
+        Logger.tag(TAG).debug("isLowMemory: JVM Heap: {} / {} ({})",
+                availableHeapSize, maxHeapSize, freeHeapPercentage);
 
-        Logger.tag(TAG).debug(String.format(Locale.ENGLISH, "isLowMemory: Heap: %d / %d (%f)", availableHeapSize, maxHeapSize, freeHeapPercentage));
+        boolean isLowMemory = false;
 
-        ActivityManager.MemoryInfo mi = new ActivityManager.MemoryInfo();
-        ActivityManager activityManager = (ActivityManager) getSystemService(ACTIVITY_SERVICE);
-        activityManager.getMemoryInfo(mi);
-        long nativeHeapSize = mi.totalMem;
-        long nativeHeapFreeSize = mi.availMem;
-        float nativeHeapPercentage = (float)nativeHeapFreeSize / nativeHeapSize;
+        if (freeHeapPercentage < 0.10) {
+            isLowMemory = true;
+        } else {
+            // JVM mem is OK, check native mem
+            ActivityManager.MemoryInfo mi = new ActivityManager.MemoryInfo();
+            ActivityManager activityManager = (ActivityManager) getSystemService(ACTIVITY_SERVICE);
+            activityManager.getMemoryInfo(mi);
+            long nativeHeapSize = mi.totalMem;
+            long nativeHeapFreeSize = mi.availMem;
+            float nativeHeapPercentage = (float) nativeHeapFreeSize / nativeHeapSize;
+            Logger.tag(TAG).debug("isLowMemory: Native Heap: {} / {} ({})",
+                    nativeHeapFreeSize, nativeHeapSize, nativeHeapPercentage);
 
-        Logger.tag(TAG).debug(String.format(Locale.ENGLISH, "isLowMemory: Native Heap: %d / %d (%f)", nativeHeapFreeSize, nativeHeapSize, nativeHeapPercentage));
+            if (nativeHeapPercentage < 0.10)
+                isLowMemory = true;
+        }
 
-        boolean isLowMemory = (freeHeapPercentage < 0.10) || (nativeHeapPercentage < 0.10);
-
-        Logger.tag(TAG).debug(String.format("isLowMemory: Result = %s", isLowMemory));
+        Logger.tag(TAG).debug("isLowMemory: Result = {}", isLowMemory);
+        Trace.endSection();
         return isLowMemory;
     }
 

--- a/iNaturalist/src/main/java/org/inaturalist/android/ObservationCursorAdapter.java
+++ b/iNaturalist/src/main/java/org/inaturalist/android/ObservationCursorAdapter.java
@@ -10,15 +10,18 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
+import android.content.res.Resources;
 import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
 import android.graphics.Typeface;
+import android.graphics.drawable.Drawable;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.net.Uri;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Trace;
@@ -73,6 +76,7 @@ import static android.content.Context.MODE_PRIVATE;
 class ObservationCursorAdapter extends SimpleCursorAdapter implements AbsListView.OnScrollListener {
     private static final String TAG = "SimpleCursorAdapter";
     private final ActivityHelper mHelper;
+    private final Resources mResources;
 
     private int mDimension;
     private HashMap<String, String[]> mPhotoInfo = new HashMap<>();
@@ -124,6 +128,7 @@ class ObservationCursorAdapter extends SimpleCursorAdapter implements AbsListVie
         mContext = (Activity)context;
         mApp = (INaturalistApp) mContext.getApplicationContext();
         mHelper = new ActivityHelper(mContext);
+        mResources = context.getResources();
 
         getPhotoInfo(true);
 
@@ -528,10 +533,9 @@ class ObservationCursorAdapter extends SimpleCursorAdapter implements AbsListVie
         Trace.beginSection("photo");
         String iconicTaxonName = c.getString(c.getColumnIndexOrThrow(Observation.ICONIC_TAXON_NAME));
 
-        int iconResource = getIconicTaxonDrawable(iconicTaxonName);
-
+        Drawable iconResource = getIconicTaxonDrawable(mResources, iconicTaxonName);
         obsIconicImage.setVisibility(View.VISIBLE);
-        obsIconicImage.setImageResource(iconResource);
+        obsIconicImage.setImageDrawable(iconResource);
         obsImage.setVisibility(View.INVISIBLE);
 
         if (photoInfo != null) {
@@ -1244,42 +1248,62 @@ class ObservationCursorAdapter extends SimpleCursorAdapter implements AbsListVie
         ContextCompat.startForegroundService(mContext, serviceIntent);
     }
 
-    public static int getIconicTaxonDrawable(String iconicTaxonName) {
-        int iconResource;
+    static HashMap<String, Drawable> taxonIconCache = new HashMap<>();
+    public static Drawable getIconicTaxonDrawable(Resources res, String iconicTaxonName) {
 
-        if (iconicTaxonName == null) {
-            iconResource = R.drawable.iconic_taxon_unknown;
-        } else if (iconicTaxonName.equals("Animalia")) {
-            iconResource = R.drawable.iconic_taxon_animalia;
-        } else if (iconicTaxonName.equals("Plantae")) {
-            iconResource = R.drawable.iconic_taxon_plantae;
-        } else if (iconicTaxonName.equals("Chromista")) {
-            iconResource = R.drawable.iconic_taxon_chromista;
-        } else if (iconicTaxonName.equals("Fungi")) {
-            iconResource = R.drawable.iconic_taxon_fungi;
-        } else if (iconicTaxonName.equals("Protozoa")) {
-            iconResource = R.drawable.iconic_taxon_protozoa;
-        } else if (iconicTaxonName.equals("Actinopterygii")) {
-            iconResource = R.drawable.iconic_taxon_actinopterygii;
-        } else if (iconicTaxonName.equals("Amphibia")) {
-            iconResource = R.drawable.iconic_taxon_amphibia;
-        } else if (iconicTaxonName.equals("Reptilia")) {
-            iconResource = R.drawable.iconic_taxon_reptilia;
-        } else if (iconicTaxonName.equals("Aves")) {
-            iconResource = R.drawable.iconic_taxon_aves;
-        } else if (iconicTaxonName.equals("Mammalia")) {
-            iconResource = R.drawable.iconic_taxon_mammalia;
-        } else if (iconicTaxonName.equals("Mollusca")) {
-            iconResource = R.drawable.iconic_taxon_mollusca;
-        } else if (iconicTaxonName.equals("Insecta")) {
-            iconResource = R.drawable.iconic_taxon_insecta;
-        } else if (iconicTaxonName.equals("Arachnida")) {
-            iconResource = R.drawable.iconic_taxon_arachnida;
-        } else {
-            iconResource = R.drawable.iconic_taxon_unknown;
+        // Yes, this is not thread safe. That's OK for this simple usage
+        if (taxonIconCache.containsKey(iconicTaxonName))
+            return taxonIconCache.get(iconicTaxonName);
+
+        int iconResource = R.drawable.iconic_taxon_unknown;
+        if (iconicTaxonName != null) {
+            switch (iconicTaxonName) {
+                case "Animalia":
+                    iconResource = R.drawable.iconic_taxon_animalia;
+                    break;
+                case "Plantae":
+                    iconResource = R.drawable.iconic_taxon_plantae;
+                    break;
+                case "Chromista":
+                    iconResource = R.drawable.iconic_taxon_chromista;
+                    break;
+                case "Fungi":
+                    iconResource = R.drawable.iconic_taxon_fungi;
+                    break;
+                case "Protozoa":
+                    iconResource = R.drawable.iconic_taxon_protozoa;
+                    break;
+                case "Actinopterygii":
+                    iconResource = R.drawable.iconic_taxon_actinopterygii;
+                    break;
+                case "Amphibia":
+                    iconResource = R.drawable.iconic_taxon_amphibia;
+                    break;
+                case "Reptilia":
+                    iconResource = R.drawable.iconic_taxon_reptilia;
+                    break;
+                case "Aves":
+                    iconResource = R.drawable.iconic_taxon_aves;
+                    break;
+                case "Mammalia":
+                    iconResource = R.drawable.iconic_taxon_mammalia;
+                    break;
+                case "Mollusca":
+                    iconResource = R.drawable.iconic_taxon_mollusca;
+                    break;
+                case "Insecta":
+                    iconResource = R.drawable.iconic_taxon_insecta;
+                    break;
+                case "Arachnida":
+                    iconResource = R.drawable.iconic_taxon_arachnida;
+                    break;
+            }
         }
 
-        return iconResource;
+        Drawable d = res.getDrawable(iconResource, null);
+        if (iconicTaxonName != null)
+            taxonIconCache.put(iconicTaxonName, d);
+        return d;
     }
 
     public void updateProgress(float progress) {

--- a/iNaturalist/src/main/java/org/inaturalist/android/ObservationCursorAdapter.java
+++ b/iNaturalist/src/main/java/org/inaturalist/android/ObservationCursorAdapter.java
@@ -673,9 +673,9 @@ class ObservationCursorAdapter extends SimpleCursorAdapter implements AbsListVie
         boolean syncNeeded = updatedAt > syncedAt;
 
         if (syncedAt == 0) {
-            Logger.tag(TAG).debug("getView %d: %s: Sync needed - syncedAt == null", position, speciesGuessValue);
+            Logger.tag(TAG).debug("getView {}: {}: Sync needed - syncedAt == null", position, speciesGuessValue);
         } else if (updatedAt > syncedAt) {
-            Logger.tag(TAG).debug("getView %d: %s: Sync needed - updatedAt (%s) > sycnedAt (%s)",
+            Logger.tag(TAG).debug("getView {}: {}: Sync needed - updatedAt ({}) > sycnedAt ({})",
                     position, speciesGuessValue, updatedAt, syncedAt);
         }
 
@@ -686,13 +686,13 @@ class ObservationCursorAdapter extends SimpleCursorAdapter implements AbsListVie
                 photoInfo[3] != null) {
             if (photoInfo[4] == null) {
                 syncNeeded = true;
-                Logger.tag(TAG).debug("getView %d: %s: Sync needed - photoInfo == null - %s / %s / %s / %s / %s",
+                Logger.tag(TAG).debug("getView {}: {}: Sync needed - photoInfo == null - {} / {} / {} / {} / {}",
                         position, speciesGuessValue, photoInfo[0], photoInfo[1], photoInfo[2], photoInfo[3], photoInfo[4]);
             } else {
                 Long photoSyncedAt = Long.parseLong(photoInfo[4]);
                 Long photoUpdatedAt = Long.parseLong(photoInfo[3]);
                 if (photoUpdatedAt > photoSyncedAt) {
-                    Logger.tag(TAG).debug("getView %d: %s: Sync needed - photoUpdatedAt (%d) > photoSyncedAt (%d)",
+                    Logger.tag(TAG).debug("getView {}: {}: Sync needed - photoUpdatedAt ({}) > photoSyncedAt ({})",
                             position, speciesGuessValue, photoUpdatedAt, photoSyncedAt);
                     syncNeeded = true;
                 }

--- a/iNaturalist/src/main/java/org/inaturalist/android/UserActivitiesAdapter.java
+++ b/iNaturalist/src/main/java/org/inaturalist/android/UserActivitiesAdapter.java
@@ -10,6 +10,7 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapShader;
 import android.graphics.Canvas;
 import android.graphics.Paint;
+import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Build;
 import androidx.core.content.ContextCompat;
@@ -271,11 +272,11 @@ class UserActivitiesAdapter extends ArrayAdapter<String> {
 
         // Get first image for the observation
         Cursor opc = mContext.getContentResolver().query(ObservationPhoto.CONTENT_URI, ObservationPhoto.PROJECTION, "observation_id = ?", new String[] { String.valueOf(obsId) }, ObservationPhoto.DEFAULT_SORT_ORDER);
-        int iconicTaxonDrawable = ObservationCursorAdapter.getIconicTaxonDrawable(obs.iconic_taxon_name);
+        Drawable iconicTaxonDrawable = ObservationCursorAdapter.getIconicTaxonDrawable(mContext.getResources(), obs.iconic_taxon_name);
 
         if (opc.getCount() == 0) {
             // No photos for observation - just show iconic taxon image
-            obsPic.setImageResource(iconicTaxonDrawable);
+            obsPic.setImageDrawable(iconicTaxonDrawable);
         } else {
             // Show first photo
             ObservationPhoto op = new ObservationPhoto(opc);

--- a/urlImageViewHelper/build.gradle
+++ b/urlImageViewHelper/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion 19
     buildToolsVersion '29.0.2'
+    useLibrary  'org.apache.http.legacy'
 
     defaultConfig {
         minSdkVersion 8


### PR DESCRIPTION
I did some profiling of the observation list. About 95% of the dropped frames are caused by very slow calls to `Adapter#getView`, so I wanted to see what could be done without major refactors. 

As context, `getView` needs to return in under 16ms for the system to maintain 60fps, otherwise it will drop the frame and try again next time. Before this PR, the average time for `ObservationCursorAdapter#getView` on my tester device was 16ms, so a small delay anywhere (lock contention, rendering system delay, random OS noise, etc) would cause a dropped frame. Also, anything above average (which by definition is about 50% of all calls to getView). This is a big part of why rapidly scrolling the list feels a bit stuttery, especially on an older device. With this PR, it now runs in about 9ms, with no feature changes to the app. Most of this PR is just moving code around to optimize code flows and delay/avoid expensive calls, there is very little rewritten / new code required. 

There is still work that can be done to bring this 9ms down more, and it would be good to do so, because there are still a fair number of dropped frames. In many cases Android must call getView multiple times in one draw cycle (e.g. just opening the list, we have to call getView for every onscreen row) which means we drop frames until this completes. A similar effect happens on a rapid scroll. 

Here are the highlights of why `getView` is slow: 
1) Formatting the observation date on every row
    Slow because date formatting is quite complex underneath. This is mostly fixed by this PR, which replaces the default `SimpleDateFormatter` with the apache `FastDateFormatter` that exists specifically to combat this issue
2) Checking for low memory
    This triggers inter process communication which is relatively slow. 2-5ms per IPC call is common, and spikes up to 10ms are also commonly seen. Before this PR, each call to `getView` required two calls to `isLowMem`. This is somewhat fixed by reducing this to one instead of two and rewriting `isLowMem` to avoid the binder call if we are already low on JVM memory. I suspect more could be done here
3) Checking if existing observation requires a sync
     This is also slow due to IPC. Every call to `getView` requires querying the `ObservationPhoto` database to check if this observation row has new photos. This is very expensive. This PR only identifies the issue, no work was put into optimizing it away. 
 4) Of note: No significant issues were found with layout inflating. I profiled both the initial inflation (it's good) and the view holder (it's caching well). I mention this because it is a common issue, so it may be useful to know that's not a concern here IMO

I added some Tracing sections to the app. These are OK to leave in production code - they effectively become no-ops. 

### Trace Before This PR

<img width="1562" alt="3-00b4df0-added-trace-sections" src="https://user-images.githubusercontent.com/305380/103854933-9113e180-507f-11eb-8e66-b02912c55500.png">

This is a pretty typical call to `getVeiw`. Note the three main sections are photo (loading the observation photo), timestamp (format the timestamp), and syncNeeded. Other sections of getView are also present, but at this zoom level they only show as tiny slices. These are the big three. 

### Researching Slow Obs Photo Load

<img width="744" alt="5-before-recursive" src="https://user-images.githubusercontent.com/305380/103855113-eea82e00-507f-11eb-9938-840e9967d7a7.png">

Trace made before I fixed isLowMem. Note (compare with prior trace image) that the timestamp section is already much faster - previously it took more time than photo loading, now it's about 1/10th of photo loading. 

We can see the recursive nature of the photo load call (e..g the `online` section re-calls `isLowMem` then `online`). Not every call to load obs photo becomes recursive, but the vast majority do (as we load the low-res then typically we recursively load the high-res version of the observation image). 

I had originally thought the issue would be bitmap decoding, but it was actually the call to `isLowMem` and the IPC inside that call. I did slightly optimize the bitmap decoding for the taxonic icons we use as placeholders (by caching them in-memory instead of reading and decoding on every call to getView), but that only gained about 0.5ms (by consuming about 10KB of memory, a good trade!). The bulk of the improvement here was to avoid calling `isLowMem` on both the initial and recursive call, and only call it during the initial call. I also moved the call deeper into the method to avoid it entirely if one of the method's fast-fail conditions was activated. 

### Status after PR

You can download a [trace file here](https://www.dropbox.com/s/2in7jdh9nyv2evt/trace-goldfish_x86-RSR1.201013.001-2021-01-03-12-12-06.perfetto-trace?dl=0). Load it up in [https://ui.perfetto.dev/](https://ui.perfetto.dev/), no need to install anything. 

Here's an image of a few typical calls to getView. We still see that isLowMem and checking if sync is needed for an existing observation are the main time costs in each call. Timestamp rendering is effectively minimized. If we switched from the polling approach currently used by isLowMem to the android recommended callback approach, we could likely completely eliminate the isLowMem time from this call. I need to dig into the sync needed issues, I suspect we can pretty easily turn two binder calls into one without changing too much 

<img width="876" alt="Screen Shot 2021-01-07 at 12 38 52 AM" src="https://user-images.githubusercontent.com/305380/103855646-1fd52e00-5081-11eb-8e2d-0b81620f32aa.png">


