### PR TITLE
Fixed Wikimedia Commons compatibility tags for licenses

### DIFF
--- a/iNaturalist/src/main/res/values/license_types.xml
+++ b/iNaturalist/src/main/res/values/license_types.xml
@@ -47,10 +47,10 @@
 	<string name="license_wikimedia_cc0">1</string>
 	<string name="license_wikimedia_cc_by">1</string>
 	<string name="license_wikimedia_cc_by_nc">0</string>
-	<string name="license_wikimedia_cc_by_nc_sa">1</string>
+	<string name="license_wikimedia_cc_by_nc_sa">0</string>
 	<string name="license_wikimedia_cc_by_nc_nd">0</string>
 	<string name="license_wikimedia_cc_by_nd">0</string>
-	<string name="license_wikimedia_cc_by_sa">0</string>
+	<string name="license_wikimedia_cc_by_sa">1</string>
 	<string name="license_wikimedia_no_license">0</string>
 
 	<!-- License Logo -->


### PR DESCRIPTION
Fixes https://github.com/inaturalist/iNaturalistAndroid/issues/1066

CC-BY-NC-SA is not Wikimedia Commons-compatible, while CC-BY-SA is.