### PR TITLE
Remove layout wrapper for AboutLicensesActivity

### DIFF
--- a/iNaturalist/src/main/res/layout/about_licenses.xml
+++ b/iNaturalist/src/main/res/layout/about_licenses.xml
@@ -1,14 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
-
     <androidx.recyclerview.widget.RecyclerView
+        xmlns:android="http://schemas.android.com/apk/res/android"
         android:id="@+id/licenses_list"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         />
-
-
-</RelativeLayout>

--- a/iNaturalist/src/main/res/layout/about_licenses.xml
+++ b/iNaturalist/src/main/res/layout/about_licenses.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-    <androidx.recyclerview.widget.RecyclerView
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        android:id="@+id/licenses_list"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        />
+<androidx.recyclerview.widget.RecyclerView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/licenses_list"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />


### PR DESCRIPTION
Minor fix which removes a redundant layout which only wrapped a RecyclerView.
