### PR TITLE
Do not translate strings

### DIFF
--- a/iNaturalist/src/main/res/values/do_not_translate.xml
+++ b/iNaturalist/src/main/res/values/do_not_translate.xml
@@ -2,5 +2,4 @@
 <resources>
     <string name="california_academy_of_sciences" translatable="false">California Academy of Sciences</string>
     <string name="national_geographic" translatable="false">National Geographic</string>
-
 </resources>

--- a/iNaturalist/src/main/res/values/do_not_translate.xml
+++ b/iNaturalist/src/main/res/values/do_not_translate.xml
@@ -2,4 +2,5 @@
 <resources>
     <string name="california_academy_of_sciences" translatable="false">California Academy of Sciences</string>
     <string name="national_geographic" translatable="false">National Geographic</string>
+
 </resources>

--- a/iNaturalist/src/main/res/values/do_not_translate.xml
+++ b/iNaturalist/src/main/res/values/do_not_translate.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="california_academy_of_sciences" translatable="false">California Academy of Sciences</string>
+    <string name="national_geographic" translatable="false">National Geographic</string>
+</resources>

--- a/iNaturalist/src/main/res/values/strings.xml
+++ b/iNaturalist/src/main/res/values/strings.xml
@@ -1194,8 +1194,6 @@
     <string name="expand_annotation_to_agree_or_disagree">Expand annotation to agree or disagree</string>
     <string name="delete_attribute_value">Delete attribute value</string>
     <string name="open_menu_for_more_options">Open menu for more options</string>
-    <string name="california_academy_of_sciences">California Academy of Sciences</string>
-    <string name="national_geographic">National Geographic</string>
     <string name="change_user_profile_photo">Change user profile photo</string>
     <string name="expand_list">Expand list</string>
     <string name="change_map_layers">Change map layers (terrain vs. satellite)</string>


### PR DESCRIPTION
Solves issue  #1086
Solution does two things.

1. Moves non-translatable strings to a file that will clearly deliminate it as not localizable to volunteers.
2. Sets `translatable` string attribute to false so that the Android OS knows not to use different strings regardless of system settings.