### PR TITLE
Bottom sheet spacing

### DIFF
--- a/iNaturalist/src/main/res/layout/new_obs_menu.xml
+++ b/iNaturalist/src/main/res/layout/new_obs_menu.xml
@@ -112,7 +112,8 @@
         android:orientation="horizontal"
         android:layout_gravity="center"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:layout_marginTop="18dp">
 
         <LinearLayout
             android:id="@+id/record_sound_container"

--- a/iNaturalist/src/main/res/layout/new_obs_menu.xml
+++ b/iNaturalist/src/main/res/layout/new_obs_menu.xml
@@ -4,7 +4,7 @@
     android:orientation="vertical" android:layout_width="match_parent"
     android:gravity="center"
     android:paddingTop="18dp"
-    android:paddingBottom="7dp"
+    android:paddingBottom="18dp"
     android:layout_height="wrap_content">
     <LinearLayout
         android:orientation="horizontal"


### PR DESCRIPTION
Made the spacing changes referenced in #1095
I also noticed that the `record_sound_container` has a margin left of 12dp, making the bottom row slightly off centered. This seems like a copy-paste error, however I didn't make the change.
File should also be auto-formatted for canonical attribute ordering and white-spacing.