### PR TITLE
Remove extra spacing on record sound button in new observation layout

### DIFF
--- a/iNaturalist/src/main/res/layout/new_obs_menu.xml
+++ b/iNaturalist/src/main/res/layout/new_obs_menu.xml
@@ -118,7 +118,6 @@
         <LinearLayout
             android:id="@+id/record_sound_container"
             android:layout_width="wrap_content"
-            android:layout_marginStart="12dp"
             android:orientation="vertical"
             android:layout_gravity="center"
             android:layout_height="wrap_content">


### PR DESCRIPTION
Fixes issue #1109 by removing the extra spacing