### PR TITLE
1113 espresso ftu tutorial failure

### DIFF
--- a/iNaturalist/src/androidTest/java/org/inaturalist/android/DefaultTestRunner.kt
+++ b/iNaturalist/src/androidTest/java/org/inaturalist/android/DefaultTestRunner.kt
@@ -1,9 +1,7 @@
 package org.inaturalist.android
 
 import android.content.Context
-import android.content.SharedPreferences
 import android.os.Bundle
-import androidx.preference.PreferenceManager
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.accessibility.AccessibilityChecks
 import androidx.test.espresso.base.DefaultFailureHandler
@@ -11,7 +9,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.runner.AndroidJUnitRunner
 import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResult
 
-class DefaultTestRunner: AndroidJUnitRunner() {
+class DefaultTestRunner : AndroidJUnitRunner() {
 
     override fun onCreate(arguments: Bundle?) {
         super.onCreate(arguments)

--- a/iNaturalist/src/androidTest/java/org/inaturalist/android/DefaultTestRunner.kt
+++ b/iNaturalist/src/androidTest/java/org/inaturalist/android/DefaultTestRunner.kt
@@ -11,10 +11,6 @@ import com.google.android.apps.common.testing.accessibility.framework.Accessibil
 
 class DefaultTestRunner : AndroidJUnitRunner() {
 
-    override fun onCreate(arguments: Bundle?) {
-        super.onCreate(arguments)
-    }
-
     override fun onStart() {
         AccessibilityChecks
             .enable()

--- a/iNaturalist/src/androidTest/java/org/inaturalist/android/DefaultTestRunner.kt
+++ b/iNaturalist/src/androidTest/java/org/inaturalist/android/DefaultTestRunner.kt
@@ -1,12 +1,21 @@
 package org.inaturalist.android
 
+import android.content.Context
+import android.content.SharedPreferences
+import android.os.Bundle
+import androidx.preference.PreferenceManager
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.accessibility.AccessibilityChecks
 import androidx.test.espresso.base.DefaultFailureHandler
+import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.runner.AndroidJUnitRunner
 import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResult
 
 class DefaultTestRunner: AndroidJUnitRunner() {
+
+    override fun onCreate(arguments: Bundle?) {
+        super.onCreate(arguments)
+    }
 
     override fun onStart() {
         AccessibilityChecks
@@ -20,6 +29,19 @@ class DefaultTestRunner: AndroidJUnitRunner() {
                     .handle(error, viewMatcher)
             }.getOrThrow()
         }
+
+        disableFirstTimeUserTutorial()
+
         super.onStart()
+    }
+
+    private fun disableFirstTimeUserTutorial() {
+        val targetContext = InstrumentationRegistry.getInstrumentation().targetContext
+        val preferencesEditor = targetContext.getSharedPreferences(
+            "iNaturalistPreferences",
+            Context.MODE_PRIVATE
+        ).edit()
+        preferencesEditor.putBoolean("first_time", false)
+        preferencesEditor.commit()
     }
 }


### PR DESCRIPTION
Fixes issue #1113 by setting the "first_time" shared preference to false in the default test runner.
This should be the desired behavior for the majority of tests; another runner should be made to test the first time user experience.